### PR TITLE
updated stray version tags to 1.2.2

### DIFF
--- a/Api/api.py
+++ b/Api/api.py
@@ -13,7 +13,7 @@ conn = Connection()
 api_v1 = Blueprint("api", __name__, url_prefix="/api")
 api = Api(
     api_v1,
-    version="1.2.1",
+    version="1.2.2",
     title="Simple Secrets Manager",
     description="Secrets management simplified",
     authorizations=authorizations,

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM python:3.13-slim-bookworm
 
 LABEL org.opencontainers.image.title="Simple Secrets Manager"
-LABEL org.opencontainers.image.version="1.2.1"
+LABEL org.opencontainers.image.version="1.2.2"
 LABEL org.opencontainers.image.authors="Krishnakanth Alagiri"
 LABEL org.opencontainers.image.url="https://github.com/bearlike/simple-secrets-manager"
 LABEL org.opencontainers.image.source="https://github.com/bearlike/simple-secrets-manager"

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@
 # $ docker login -u <username>
 #
 # We try to follow [SemVer v2.0.0](https://semver.org/)
-VERSION="1.2.1"
+VERSION="1.2.2"
 IMAGE_NAME="ghcr.io/bearlike/simple-secrets-manager"
 # If $VERSION = "1.2.3"
 # ${VERSION::3} will be "1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simple-secrets-manager"
-version = "1.2.1"
+version = "1.2.2"
 description = "Securely store and deliver tokens, passwords, API keys, and other secrets using HTTP API, Swagger UI, or Python Package."
 authors = [
     { name = "Krishnakanth Alagiri", email = "39209037+bearlike@users.noreply.github.com" },


### PR DESCRIPTION
some version tags needed updating to 1.2.2.

This is obvious on the 1.2.2 docker image in the swagger api:
<img width="433" alt="image" src="https://github.com/user-attachments/assets/81fa7d88-3493-43df-b5aa-d90bf25c883d" />
